### PR TITLE
fixing up for new azurerm provider version

### DIFF
--- a/labs/1.0/README.md
+++ b/labs/1.0/README.md
@@ -12,7 +12,7 @@ Let's add the AzureRM resource provider of a specific version. To do this add th
 
 ```
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 ```
 
@@ -22,7 +22,7 @@ We also want to add the "random" provider, as we have already discussed this wil
 
 ```
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 ```
 

--- a/labs/1.1/main.tf
+++ b/labs/1.1/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 resource "azurerm_resource_group" "lab" {
   name     = "lab-1-1"

--- a/labs/1.2/README.md
+++ b/labs/1.2/README.md
@@ -45,7 +45,7 @@ resource "azurerm_function_app" "lab" {
   
   ...  
 
-  app_settings {
+  app_settings = {
       ABC = "XYZ"
   }
 }

--- a/labs/1.2/main.tf
+++ b/labs/1.2/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 resource "azurerm_resource_group" "lab" {
   name     = "lab-1-2"

--- a/labs/1.3/README.md
+++ b/labs/1.3/README.md
@@ -28,7 +28,7 @@ resource "azurerm_function_app" "lab" {
   
   version = "~2"
 
-  app_settings {
+  app_settings = {
     ABC = "XYZ"
   }
 }

--- a/labs/1.3/main.tf
+++ b/labs/1.3/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 resource "azurerm_resource_group" "lab" {
   name     = "lab-1-3"

--- a/labs/1.4/main.tf
+++ b/labs/1.4/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 resource "azurerm_resource_group" "lab" {
   name     = "lab-1-4"

--- a/labs/2.0/main.tf
+++ b/labs/2.0/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 resource "azurerm_resource_group" "lab" {
   name     = "lab-2-0"

--- a/labs/2.1/main.tf
+++ b/labs/2.1/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 resource "azurerm_resource_group" "lab" {
   name     = "lab-2-1"

--- a/labs/3.0/function/main.tf
+++ b/labs/3.0/function/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 
 resource "random_id" "lab" {

--- a/labs/3.0/main.tf
+++ b/labs/3.0/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 resource "azurerm_resource_group" "lab" {

--- a/labs/4.0/main.tf
+++ b/labs/4.0/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "1.22"
+  version = "1.28"
 }
 
 provider "azuread" {
@@ -7,7 +7,7 @@ provider "azuread" {
 }
 
 provider "random" {
-  version = "1.3"
+  version = "2.1"
 }
 
 resource "azurerm_resource_group" "lab" {


### PR DESCRIPTION
The new azurerm provider and new terraform version aren't compatible with the the ones mentioned in the lab.  This should resolve those including the new syntax for app_settings